### PR TITLE
enhancement: `ScrollPhysics` can be modified

### DIFF
--- a/lib/draggable_home.dart
+++ b/lib/draggable_home.dart
@@ -75,40 +75,42 @@ class DraggableHome extends StatefulWidget {
   final Widget? bottomNavigationBar;
 
   /// floatingActionButtonLocation: An object that defines a position for the FloatingActionButton based on the Scaffold's ScaffoldPrelayoutGeometry.
-
   final FloatingActionButtonLocation? floatingActionButtonLocation;
 
   /// floatingActionButtonAnimator: Provider of animations to move the FloatingActionButton between FloatingActionButtonLocations.
   final FloatingActionButtonAnimator? floatingActionButtonAnimator;
 
+  final ScrollPhysics? physics;
+
   /// This will create DraggableHome.
-  const DraggableHome({
-    Key? key,
-    this.leading,
-    required this.title,
-    this.centerTitle = true,
-    this.actions,
-    this.alwaysShowLeadingAndAction = false,
-    this.alwaysShowTitle = false,
-    this.headerExpandedHeight = 0.35,
-    required this.headerWidget,
-    this.headerBottomBar,
-    this.backgroundColor,
-    this.appBarColor,
-    this.curvedBodyRadius = 20,
-    required this.body,
-    this.drawer,
-    this.fullyStretchable = false,
-    this.stretchTriggerOffset = 200,
-    this.expandedBody,
-    this.stretchMaxHeight = 0.9,
-    this.bottomSheet,
-    this.bottomNavigationBarHeight = kBottomNavigationBarHeight,
-    this.bottomNavigationBar,
-    this.floatingActionButton,
-    this.floatingActionButtonLocation,
-    this.floatingActionButtonAnimator,
-  })  : assert(headerExpandedHeight > 0.0 &&
+  const DraggableHome(
+      {Key? key,
+      this.leading,
+      required this.title,
+      this.centerTitle = true,
+      this.actions,
+      this.alwaysShowLeadingAndAction = false,
+      this.alwaysShowTitle = false,
+      this.headerExpandedHeight = 0.35,
+      required this.headerWidget,
+      this.headerBottomBar,
+      this.backgroundColor,
+      this.appBarColor,
+      this.curvedBodyRadius = 20,
+      required this.body,
+      this.drawer,
+      this.fullyStretchable = false,
+      this.stretchTriggerOffset = 200,
+      this.expandedBody,
+      this.stretchMaxHeight = 0.9,
+      this.bottomSheet,
+      this.bottomNavigationBarHeight = kBottomNavigationBarHeight,
+      this.bottomNavigationBar,
+      this.floatingActionButton,
+      this.floatingActionButtonLocation,
+      this.floatingActionButtonAnimator,
+      this.physics})
+      : assert(headerExpandedHeight > 0.0 &&
             headerExpandedHeight < stretchMaxHeight),
         assert(
           (stretchMaxHeight > headerExpandedHeight) && (stretchMaxHeight < .95),
@@ -183,7 +185,7 @@ class _DraggableHomeState extends State<DraggableHome> {
     double topPadding,
   ) {
     return CustomScrollView(
-      physics: const BouncingScrollPhysics(),
+      physics: widget.physics ?? const BouncingScrollPhysics(),
       slivers: [
         StreamBuilder<List<bool>>(
           stream: CombineLatestStream.list<bool>([


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

**Yes**

## Description

I am very happy to find this package. It helps me to make very nice UI for my app, but there is one problem that I am facing is:

- When `body` is a `List<Widget>` but element in that just a `SizedBox` or for example I want to show my blogs in there, if haven't any blogs, i want to lock the scroll and UI still scrolls the `body`, it is very terrible for me because nothing in there or had so many white space, this attachment is demo video:
[Screencast from 10-10-2022 18:12:42.webm](https://user-images.githubusercontent.com/63831488/194854023-a871d510-6323-42ab-8297-3e14f4e6ce87.webm)

My solution is: add `physics` to modify the `ScrollPhysics` to implement some cases of UI when developers need (by default still is `BouncingScrollPhysics`)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore